### PR TITLE
Update console text colors for dark theme

### DIFF
--- a/src/main/resources/themes/DarkLauncherLaf.properties
+++ b/src/main/resources/themes/DarkLauncherLaf.properties
@@ -8,10 +8,10 @@ ProgressBar.foreground          = #404b5d
 
 AccountItem.borderColor         = #4b6eaf
 
-LauncherConsole.infoColor       = #000000
+LauncherConsole.infoColor       = #e5e5e5
 LauncherConsole.warnColor       = #b2b200
-LauncherConsole.errorColor      = #b20000
-LauncherConsole.debugColor      = #00b2b2
+LauncherConsole.errorColor      = #ff6c6c
+LauncherConsole.debugColor      = #1cbdea
 
 # Nothing, no border
 ScrollPane.border =


### PR DESCRIPTION
The current uses the light theme's colors though this did not change warn.

Sample from testing on GIMP:
![image](https://github.com/user-attachments/assets/2e69b877-46e4-42aa-8ea8-f0a1dade6837)
