### PR TITLE
Use Longs rather than Integers for comparing version numbers

### DIFF
--- a/src/main/java/me/theentropyshard/crlauncher/cosmic/mods/cosmicquilt/maven/MavenDownloader.java
+++ b/src/main/java/me/theentropyshard/crlauncher/cosmic/mods/cosmicquilt/maven/MavenDownloader.java
@@ -180,8 +180,8 @@ public class MavenDownloader {
 
         int length = Math.max(v1Parts.length, v2Parts.length);
         for (int i = 0; i < length; i++) {
-            int v1Part = i < v1Parts.length && !v1Parts[i].replaceAll("\\D+", "").isEmpty() ? Integer.parseInt(v1Parts[i].replaceAll("\\D+", "")) : 0;
-            int v2Part = i < v2Parts.length && !v2Parts[i].replaceAll("\\D+", "").isEmpty() ? Integer.parseInt(v2Parts[i].replaceAll("\\D+", "")) : 0;
+            long v1Part = i < v1Parts.length && !v1Parts[i].replaceAll("\\D+", "").isEmpty() ? Long.parseLong(v1Parts[i].replaceAll("\\D+", "")) : 0;
+            long v2Part = i < v2Parts.length && !v2Parts[i].replaceAll("\\D+", "").isEmpty() ? Long.parseLong(v2Parts[i].replaceAll("\\D+", "")) : 0;
             if (v1Part < v2Part)
                 return 1;
             if (v1Part > v2Part)


### PR DESCRIPTION
As tittle says.\
This'll fix an upcoming bug due to one of the dependencies having the version `201802261711` which is larger than the integer's max value (`2147483647`) causing it to fail.