### PR TITLE
[FIX] update the crmm api domain

### DIFF
--- a/src/main/java/me/theentropyshard/crlauncher/crmm/CrmmApi.java
+++ b/src/main/java/me/theentropyshard/crlauncher/crmm/CrmmApi.java
@@ -35,7 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CrmmApi {
-    public static final String BASE_URL = "https://api.crmm.tech/api/";
+    public static final String BASE_URL = "https://api.crmods.org/api/";
 
     private final Retrofit retrofit;
     private final CrmmHttpApi crmmApi;


### PR DESCRIPTION
The old crmm.tech domain has expired, so update the api url to use the new domain